### PR TITLE
add job to scheduler instead of running immediately

### DIFF
--- a/backend/app/core/scheduler.py
+++ b/backend/app/core/scheduler.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime
 
 from apscheduler.schedulers.background import BackgroundScheduler
 

--- a/backend/app/tests/test_core.py
+++ b/backend/app/tests/test_core.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime
 from unittest.mock import ANY, MagicMock, patch
 
 from sqlalchemy.orm import Session


### PR DESCRIPTION
Prevents email processing from blocking other requests when booting the app. I noticed if you have a lot of emails to process, this can block the main thread and you'll end up with errors on the frontend
