### PR TITLE
fix: send IMAP client ID before mailbox operations

### DIFF
--- a/backend/app/core/imap.py
+++ b/backend/app/core/imap.py
@@ -7,12 +7,24 @@ from app.core.logging import get_logger
 logger = get_logger(__name__)
 
 
+def send_client_id(mail: imaplib.IMAP4_SSL) -> None:
+    """Send IMAP client identity for providers that require RFC 2971 ID."""
+    imaplib.Commands.setdefault("ID", ("AUTH", "SELECTED"))
+    try:
+        mail._simple_command(
+            "ID", '("name" "LetterFeed" "version" "0.4.0" "vendor" "LetterFeed")'
+        )
+    except Exception as e:
+        logger.warning(f"Failed to send IMAP ID command: {e}")
+
+
 def _test_imap_connection(server, username, password):
     """Test the IMAP connection with the given credentials."""
     logger.info(f"Testing IMAP connection to {server} for user {username}")
     try:
         mail = imaplib.IMAP4_SSL(server)
         mail.login(username, password)
+        send_client_id(mail)
         mail.logout()
         logger.info("IMAP connection successful")
         return True, "Connection successful"
@@ -27,6 +39,7 @@ def get_folders(server, username, password):
     try:
         mail = imaplib.IMAP4_SSL(server)
         mail.login(username, password)
+        send_client_id(mail)
         status, folders = mail.list()
         mail.logout()
         if status == "OK":

--- a/backend/app/services/email_processor.py
+++ b/backend/app/services/email_processor.py
@@ -10,6 +10,7 @@ from bs4 import BeautifulSoup
 from readability import Document
 from sqlalchemy.orm import Session
 
+from app.core.imap import send_client_id
 from app.core.logging import get_logger
 from app.crud.entries import create_entry, get_entry_by_message_id
 from app.crud.newsletters import create_newsletter, get_newsletters
@@ -43,6 +44,7 @@ def _connect_to_imap(
         logger.info(f"Connecting to IMAP server: {settings.imap_server}")
         mail = imaplib.IMAP4_SSL(settings.imap_server)
         mail.login(settings.imap_username, settings.imap_password)
+        send_client_id(mail)
         status, messages = mail.select(search_folder)
         if status != "OK":
             logger.error(

--- a/backend/app/tests/test_core.py
+++ b/backend/app/tests/test_core.py
@@ -3,7 +3,7 @@ from unittest.mock import ANY, MagicMock, patch
 
 from sqlalchemy.orm import Session
 
-from app.core.imap import _test_imap_connection, get_folders
+from app.core.imap import _test_imap_connection, get_folders, send_client_id
 from app.crud.newsletters import create_newsletter
 from app.crud.settings import create_or_update_settings
 from app.schemas.newsletters import NewsletterCreate
@@ -43,6 +43,18 @@ def test_get_folders(mock_imap):
     assert folders == ["INBOX", "Processed"]
 
 
+def test_send_client_id_registers_and_sends_imap_id_command():
+    """Test sending IMAP client identity for providers that require it."""
+    mock_mail = MagicMock()
+    mock_mail._simple_command.return_value = ("OK", [b"ID completed"])
+
+    send_client_id(mock_mail)
+
+    mock_mail._simple_command.assert_called_once_with(
+        "ID", '("name" "LetterFeed" "version" "0.4.0" "vendor" "LetterFeed")'
+    )
+
+
 @patch("app.services.email_processor.imaplib.IMAP4_SSL")
 def test_process_emails(mock_imap, db_session: Session):
     """Test processing emails."""
@@ -78,6 +90,9 @@ def test_process_emails(mock_imap, db_session: Session):
 
     # Assertions
     mock_mail.login.assert_called_once_with("test@test.com", "password")
+    mock_mail._simple_command.assert_called_once_with(
+        "ID", '("name" "LetterFeed" "version" "0.4.0" "vendor" "LetterFeed")'
+    )
     mock_mail.select.assert_called_once_with("INBOX")
     mock_mail.search.assert_called_once_with(None, "(UNSEEN)")
     mock_mail.fetch.assert_called_once_with(b"1", "(BODY.PEEK[])")


### PR DESCRIPTION
## Summary
- Send an RFC 2971 IMAP `ID` command after login before mailbox operations.
- Reuse the client identity step for connection tests, folder listing, and email processing.
- Add regression coverage for the IMAP `ID` command and the email processing connection flow.

## Why
Some IMAP providers, including NetEase/163, allow login but reject `SELECT INBOX` with `SELECT Unsafe Login` unless the client identifies itself first.

## Test Plan
- `cd backend && uv run pytest -q`
- Verified against a live `imap.163.com` account: login, `SELECT INBOX`, and unseen search returned `OK` after sending client ID.
